### PR TITLE
Test that inputs can be missing and it still starts up

### DIFF
--- a/context/on_startup.py
+++ b/context/on_startup.py
@@ -7,14 +7,14 @@ if __name__ =="__main__":
     # Using environ.get to be a little more robust against missing values.
 
     with open("envvar_value.json", "w") as f:
-        f.write(
-            os.environ.get("INPUT_JSON")
-        )
+        json = os.environ.get("INPUT_JSON")
+        if json:
+            f.write(json)
 
     with open("envvar_url.json", "w") as f:
-        f.write(
-            requests.get(os.environ.get("INPUT_JSON_URL")).text
-        )
+        url = os.environ.get("INPUT_JSON_URL")
+        if url:
+            f.write(requests.get(url).text)
 
     print('envvars read')
 

--- a/test.py
+++ b/test.py
@@ -46,19 +46,19 @@ class ContainerTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('Tool Launch Data', response.text)
 
-    @unittest.skipIf(get_args().skip_mounted, 'skip mounted')
+    @unittest.skipIf(get_args().skip_mounted, 'CLI param skip')
     def test_mounted_json(self):
         response = requests.get(self.base + '/data/input.json')
         self.assertEqual(response.status_code, 200)
         self.assertIn('"Nils"', response.text)
 
-    @unittest.skipIf(get_args().skip_envvar_value, 'skip envvar value')
+    @unittest.skipIf(get_args().skip_envvar_value, 'CLI param skip')
     def test_envvar_value_json(self):
         response = requests.get(self.base + '/envvar_value.json')
         self.assertEqual(response.status_code, 200)
         self.assertIn('"Chuck"', response.text)
 
-    @unittest.skipIf(get_args().skip_envvar_url, 'skip envvar url')
+    @unittest.skipIf(get_args().skip_envvar_url, 'CLI param skip')
     def test_envvar_url_json(self):
         response = requests.get(self.base + '/envvar_url.json')
         self.assertEqual(response.status_code, 200)

--- a/test.py
+++ b/test.py
@@ -1,23 +1,30 @@
 import unittest
 import subprocess
 import requests
-import sys
 import re
 import time
+import argparse
 
 
 def get_port():
     # Looks up port number for container name given in argv
     port_mapping = subprocess.check_output(
-        ['docker', 'port', sys.argv[1]]
+        ['docker', 'port', get_args().container_name]
     ).decode('utf-8').strip()
     return re.search(':(\d+)', port_mapping).group(1)
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--container_name', action='store')
+    parser.add_argument('--skip_mounted', action='store_true')
+    parser.add_argument('--skip_envvar_value', action='store_true')
+    parser.add_argument('--skip_envvar_url', action='store_true')
+    return parser.parse_args()
 
 class ContainerTest(unittest.TestCase):
 
     def setUp(self):
-        port = get_port()
-        self.base = 'http://localhost:' + port
+        self.base = 'http://localhost:' + get_port()
 
         # TODO: This didn't work on Travis... should it?
         # session = requests.Session()
@@ -34,22 +41,24 @@ class ContainerTest(unittest.TestCase):
         else:
             self.fail('Server never came up')
 
-
     def test_home_page(self):
         response = requests.get(self.base)
         self.assertEqual(response.status_code, 200)
         self.assertIn('Tool Launch Data', response.text)
 
+    @unittest.skipIf(get_args().skip_mounted, 'skip mounted')
     def test_mounted_json(self):
         response = requests.get(self.base + '/data/input.json')
         self.assertEqual(response.status_code, 200)
         self.assertIn('"Nils"', response.text)
 
+    @unittest.skipIf(get_args().skip_envvar_value, 'skip envvar value')
     def test_envvar_value_json(self):
         response = requests.get(self.base + '/envvar_value.json')
         self.assertEqual(response.status_code, 200)
         self.assertIn('"Chuck"', response.text)
 
+    @unittest.skipIf(get_args().skip_envvar_url, 'skip envvar url')
     def test_envvar_url_json(self):
         response = requests.get(self.base + '/envvar_url.json')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
The parameterized tests are weird, but this lets us be sure that any one of the modes can be left off and everything else still works. (Spent a little time trying to make a DRYer annotation, but it just got confusing.)